### PR TITLE
Fix for non-catastrophic collisions

### DIFF
--- a/breakup.py
+++ b/breakup.py
@@ -150,7 +150,7 @@ def breakup(ep, p1, p2):
 
     # if the ratio is smaller than 40 J/g then it is non-catastrophic collision
     if catastrophRatio<40:
-        M = p2.mass*dv / 1000
+        M = p2.mass*dv / 1000.0
         Lc = np.linspace(LB, 1.)
         num = int(0.1 * M ** 0.75 * LB ** -1.71)
     else:

--- a/breakup.py
+++ b/breakup.py
@@ -150,7 +150,7 @@ def breakup(ep, p1, p2):
 
     # if the ratio is smaller than 40 J/g then it is non-catastrophic collision
     if catastrophRatio<40:
-        M = p2.mass*dv
+        M = p2.mass*dv / 1000
         Lc = np.linspace(LB, 1.)
         num = int(0.1 * M ** 0.75 * LB ** -1.71)
     else:


### PR DESCRIPTION
It is me again.
As part of my bachelor' Thesis, I am implementing the NASA Breakup Model in C++ under the guidance of Pablo Gómez (@gomezzz) from ESA and Fabio Gratl (@FG-TUM). This Python implementation, therefore, was my reference implementation for the Breakup Model.

While writing my thesis, I noticed an error for non-catastrophic collision, precisely for the calculation of M. I accidentally calculated with v_impact in [m/s] instead of [km/s], which is an error:
_"In the case of a non-catastrophic collision, the value of M is defined as the mass (in kg) of the smaller object 
multiplied by the collision velocity (in km/s)."_  [1]


During the check, I noticed that this reference implementation made the same error of using the impact velocity in [m/s]. Hence, this Pull Request fixes this error by adding a division by factor 1000:

```python
  M = p2.mass*dv / 1000.0
```


Source:
[1] Johnson, Nicholas L., et al. “NASA’s new breakup model of EVOLVE 4.0” Advances in Space Research 28.9 (2001): 1377-1384